### PR TITLE
Handle User.DoesNotExist

### DIFF
--- a/pin_passcode/views.py
+++ b/pin_passcode/views.py
@@ -16,10 +16,14 @@ def auth(request):
             if not username:
                 username = 'admin'
 
-            user = get_user_model().objects.get(username=username)
-            user.backend = 'django.contrib.auth.backends.ModelBackend'
+            try:
+                user = get_user_model().objects.get(username=username)
+                user.backend = 'django.contrib.auth.backends.ModelBackend'
 
-            login(request, user)
-            return HttpResponse(status=200)
+                login(request, user)
+                return HttpResponse(status=200)
+            except get_user_model().DoesNotExist:
+                pass
+
 
     return HttpResponse(status=401)


### PR DESCRIPTION
If the entered PIN is correct, but the configured user doesn't exist, still return a 401 instead of a 500.
